### PR TITLE
Add ESP-IDF setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# ESP32C3 OTA & BLE Provisioning Framework
+
+This repository provides a basic framework for ESP32C3 devices using the ESP-IDF
+environment. The project demonstrates how to combine Bluetooth provisioning with
+OTA (Over The Air) updates.
+
+## Requirements
+- An ESP32C3 development board
+- Python 3.8+
+- Git
+
+### Setting Up ESP-IDF
+Run the provided script to install the ESP-IDF toolchain and set `IDF_PATH`:
+
+```bash
+./setup_esp_idf.sh
+```
+
+After installation, remember to source the environment before building:
+
+```bash
+source "$IDF_PATH/export.sh"
+```
+
+## Building the Example
+```bash
+source "$IDF_PATH/export.sh"  # load ESP-IDF tools
+idf.py set-target esp32c3
+idf.py menuconfig    # configure Wi-Fi credentials and OTA URL
+idf.py build
+```
+
+## Flashing and Monitoring
+```bash
+idf.py -p PORT flash monitor
+```
+Replace `PORT` with your serial port.
+
+## Project Structure
+- `ota_ble/`: ESP-IDF project containing the example code
+  - `main/app_main.c`: skeleton implementation of BLE provisioning and OTA
+
+The code is minimal and meant as a starting point. You can extend the
+provisioning logic in `start_ble_provisioning()` and customize OTA behavior in
+`perform_ota_update()`.

--- a/ota_ble/CMakeLists.txt
+++ b/ota_ble/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(ota_ble_app)

--- a/ota_ble/main/CMakeLists.txt
+++ b/ota_ble/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "app_main.c")

--- a/ota_ble/main/app_main.c
+++ b/ota_ble/main/app_main.c
@@ -1,0 +1,51 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "esp_bt.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_system.h"
+#include "esp_http_client.h"
+#include "esp_ota_ops.h"
+#include "esp_https_ota.h"
+#include "esp_prov_ble_secure.h"
+
+static const char *TAG = "OTA_BLE";
+
+static void start_ble_provisioning(void)
+{
+    ESP_LOGI(TAG, "Starting BLE provisioning");
+    /* Placeholder: configure provisioning scheme, service UUID, etc. */
+}
+
+static void perform_ota_update(void)
+{
+    ESP_LOGI(TAG, "Starting OTA update");
+    esp_http_client_config_t config = {
+        .url = "https://example.com/firmware.bin",
+        .cert_pem = NULL,
+    };
+    esp_https_ota(&config);
+}
+
+void app_main(void)
+{
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+
+    start_ble_provisioning();
+
+    /* Wait for network connection after provisioning */
+
+    perform_ota_update();
+
+    while (1) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+

--- a/setup_esp_idf.sh
+++ b/setup_esp_idf.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Simple helper to install ESP-IDF for ESP32C3
+set -e
+IDF_VERSION="v5.2"
+
+if [ -z "$IDF_PATH" ]; then
+    export IDF_PATH="$PWD/esp-idf"
+    echo "IDF_PATH not set, using $IDF_PATH"
+fi
+
+if [ ! -d "$IDF_PATH" ]; then
+    echo "Cloning ESP-IDF $IDF_VERSION..."
+    git clone --branch "$IDF_VERSION" --depth 1 https://github.com/espressif/esp-idf.git "$IDF_PATH"
+fi
+
+cd "$IDF_PATH"
+./install.sh esp32c3
+. ./export.sh
+
+echo "ESP-IDF installed. Run 'source $IDF_PATH/export.sh' before building."
+


### PR DESCRIPTION
## Summary
- document how to install ESP-IDF via new `setup_esp_idf.sh`
- include environment sourcing step in build instructions

## Testing
- `bash -x ./setup_esp_idf.sh` *(stopped after clone started)*
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb9086608333930795c73b52cd98